### PR TITLE
Do not use simpleVersion

### DIFF
--- a/src/exec/Options.hs
+++ b/src/exec/Options.hs
@@ -11,8 +11,7 @@ module Options
 import           Data.Char                   (toLower, toUpper)
 import           Options.Applicative         (ReadM, eitherReader)
 import           Options.Applicative.Simple  (Parser, auto, help, long, metavar, option,
-                                              short, simpleOptions, simpleVersion,
-                                              strOption, value)
+                                              short, simpleOptions, strOption, value)
 import           System.Directory            (getHomeDirectory)
 import           System.FilePath             ((</>))
 import           System.Wlog.Severity        (Severity (..))
@@ -67,7 +66,7 @@ getOptions = do
     homeDir <- getHomeDirectory
     (res, ()) <-
         simpleOptions
-            ("cardano-report-server, " <> $(simpleVersion version))
+            ("cardano-report-server version " <> show version)
             "CardanoSL report server"
             "CardanoSL reporting server daemon"
             (optsParser homeDir)


### PR DESCRIPTION
TLDR: it depends on parsing git revision, which can cause unnecessary
      rebuilds

gitrev (1.2.0 and newer) rebuild if there are changes made in the git
staging area.

When using stack the problem can be seen:

   Jul 04 13:03:27 cardano-report-server-0.1.2: unregistering (local file changes: .git/index)

Just cloning cardano-report-server and building it twice using

   $ stack build --nix

triggers the bug.

cc @neongreen @volhovM 

Can we merge this ASAP and make a release?