### PR TITLE
[CSL-1453] Drop scotty dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .#*
 tmp/
 TAGS
+.dir-locals.el

--- a/cardano-report-server.cabal
+++ b/cardano-report-server.cabal
@@ -1,5 +1,5 @@
 name:                cardano-report-server
-version:             0.2.0
+version:             0.2.1
 synopsis:            Reporting server for CSL
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-report-server

--- a/cardano-report-server.cabal
+++ b/cardano-report-server.cabal
@@ -82,7 +82,6 @@ executable cardano-report-server
                      , optparse-simple >= 0.0.3
                      , parsec >= 3.1.10
                      , random >= 1.1
-                     , scotty >= 0.11.0
                      , universum >= 0.2.1
                      , wai-extra >= 3.0.19
                      , warp >= 3.2.9

--- a/cardano-report-server.cabal
+++ b/cardano-report-server.cabal
@@ -39,7 +39,6 @@ library
                      , mtl >= 2.2.1
                      , network >= 2.6.3.1
                      , optparse-applicative >= 0.12.1.0
-                     , optparse-simple >= 0.0.3
                      , parsec >= 3.1.10
                      , random >= 1.1
                      , text >= 1.2.2.1

--- a/cardano-report-server.cabal
+++ b/cardano-report-server.cabal
@@ -78,7 +78,6 @@ executable cardano-report-server
                      , monad-control >= 1.0.1.0
                      , mtl >= 2.2.1
                      , optparse-applicative >= 0.12.1.0
-                     , optparse-simple >= 0.0.3
                      , parsec >= 3.1.10
                      , random >= 1.1
                      , universum >= 0.2.1

--- a/cardano-report-server.cabal
+++ b/cardano-report-server.cabal
@@ -42,7 +42,6 @@ library
                      , optparse-simple >= 0.0.3
                      , parsec >= 3.1.10
                      , random >= 1.1
-                     , scotty >= 0.11.0
                      , text >= 1.2.2.1
                      , time >= 1.6.0.1
                      , transformers >= 0.5.2.0

--- a/src/Pos/ReportServer/Exception.hs
+++ b/src/Pos/ReportServer/Exception.hs
@@ -14,8 +14,6 @@ module Pos.ReportServer.Exception
 import qualified Control.Exception.Lifted    as LiftedBase
 import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Universum
-import           Web.Scotty.Internal.Types   as S
-import           Web.Scotty.Trans            as T
 
 data ReportServerException
     = BadRequest Text
@@ -36,14 +34,3 @@ tryAll action = ((Right <$> action) `catch` handler1) `catch` handler2
   where
     handler1 (e :: ReportServerException) = pure $ Left e
     handler2 (e :: SomeException) = pure $ Left (ExternalException e)
-
-instance ScottyError ReportServerException where
-    showError = show
-    stringError t = FromTextException t
-
-instance (MonadThrow m, ScottyError e) => MonadThrow (T.ActionT e m) where
-    throwM = lift . throwM
-
-instance (MonadCatch m, ScottyError e, MonadBaseControl IO m) =>
-         MonadCatch (T.ActionT e m) where
-    catch = LiftedBase.catch

--- a/src/Pos/ReportServer/Exception.hs
+++ b/src/Pos/ReportServer/Exception.hs
@@ -11,8 +11,6 @@ module Pos.ReportServer.Exception
     , tryAll
     ) where
 
-import qualified Control.Exception.Lifted    as LiftedBase
-import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Universum
 
 data ReportServerException

--- a/src/Pos/ReportServer/Exception.hs
+++ b/src/Pos/ReportServer/Exception.hs
@@ -20,6 +20,8 @@ data ReportServerException
       -- ^ Internal storage is malformed
     | FromTextException [Char]
       -- ^ Port of scotty String exceptions
+    | ParameterNotFound Text
+      -- ^ Cannot find the parameter `key` in the params of the `Request`
     | ExternalException SomeException
       -- ^ All other exceptions
     deriving (Show)

--- a/src/Pos/ReportServer/Server.hs
+++ b/src/Pos/ReportServer/Server.hs
@@ -15,16 +15,16 @@ import           Data.List                   ((\\))
 import qualified Data.Text                   as T
 import qualified Data.Text.Encoding          as TE (decodeUtf8)
 import qualified Data.Text.Lazy              as LT
-import           Network.HTTP.Types.Status   (status200, status404, status413)
+import           Network.HTTP.Types.Status   (status200, status404, status413, Status)
 import           Network.Wai                 (Middleware, RequestBodyLength (..),
-                                              requestBodyLength, responseLBS)
+                                              Application, requestBodyLength, responseLBS,
+                                              Response, ResponseReceived, Request, requestHeaders
+                                             )
+import           Network.Wai.UrlMap (mapUrls, mount, mountRoot)
 import           Network.Wai.Parse           (fileContent)
 import           Universum
-import           Web.Scotty.Trans            (files, notFound, param, post, raise, status,
-                                              text)
-import qualified Web.Scotty.Trans            as S
 
-import           Pos.ReportServer.ClientInfo (getClientInfo)
+import           Pos.ReportServer.ClientInfo (clientInfo)
 import           Pos.ReportServer.Exception  (ReportServerException (BadRequest), tryAll)
 import           Pos.ReportServer.FileOps    (LogsHolder, addEntry)
 import           Pos.ReportServer.Report     (ReportInfo (..))
@@ -48,11 +48,20 @@ limitBodySize limit application request responseHandler =
 
 liftAndCatchIO
     :: (MonadIO m, MonadCatch m, MonadBaseControl IO m)
-    => IO a -> S.ActionT (ReportServerException) m a
-liftAndCatchIO action = either raise pure =<< tryAll (liftIO action)
+    => IO a -> m (Either ReportServerException a)
+liftAndCatchIO = tryAll . liftIO
 
-reportServerApp :: LogsHolder -> S.ScottyT ReportServerException IO ()
-reportServerApp holder = do
+type Responder = Response -> IO ResponseReceived
+
+withStatus :: Status -> T.Text -> Request -> Response
+withStatus status msg req = responseLBS status (requestHeaders req) (encodeUtf8 msg)
+
+
+reportApp :: LogsHolder -> Application
+reportApp holder req respond =
+    respond (withStatus status200 "To be done" req)
+
+{-
     post "/report" $ do
         (payload :: ReportInfo) <-
             either failPayload pure . eitherDecode =<< param "payload"
@@ -63,16 +72,23 @@ reportServerApp holder = do
         unless (null missingLogs) $ failMissingLogs missingLogs
         let neededLogs = filter ((`elem` rLogs payload) . fst) logFiles
         let payloadFile = ("payload.json", prettifyJson payload)
-        cInfo <- getClientInfo
+        let cInfo = clientInfo req
         let clientInfoFile = ("client.info", prettifyJson cInfo)
         liftAndCatchIO $ addEntry holder $ payloadFile : clientInfoFile : neededLogs
         status status200
-    notFound err404
+-}
+
+notFound :: Application
+notFound req respond = respond (withStatus status404 "Not found" req)
+
+reportServerApp :: LogsHolder -> Application
+reportServerApp holder = mapUrls $
+        mount "report" (reportApp holder)
+    <|> mountRoot notFound
   where
     prettifyJson :: (ToJSON a) => a -> Text
     prettifyJson = TE.decodeUtf8 . BSL.toStrict . encodePretty
-    err404 = status status404 >> text "Not found"
     failMissingLogs missing =
-        raise $ BadRequest $ "Logs mentioned in payload were not attached: " <> show missing
+        throwM $ BadRequest $ "Logs mentioned in payload were not attached: " <> show missing
     failPayload e =
-        raise $ BadRequest $ "Couldn't manage to parse json payload: " <> T.pack e
+        throwM $ BadRequest $ "Couldn't manage to parse json payload: " <> T.pack e

--- a/src/Pos/ReportServer/Server.hs
+++ b/src/Pos/ReportServer/Server.hs
@@ -1,31 +1,38 @@
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 module Pos.ReportServer.Server
        ( reportServerApp
        , limitBodySize
        ) where
 
+import           Control.Exception           (displayException)
 import           Control.Monad.Trans.Control (MonadBaseControl)
-import           Data.Aeson                  (ToJSON, eitherDecode)
+import           Data.Aeson                  (ToJSON, eitherDecodeStrict)
 import           Data.Aeson.Encode.Pretty    (encodePretty)
 import qualified Data.ByteString.Lazy        as BSL
-import           Data.List                   ((\\))
+import           Data.List                   (lookup, (\\))
 import qualified Data.Text                   as T
 import qualified Data.Text.Encoding          as TE (decodeUtf8)
-import qualified Data.Text.Lazy              as LT
-import           Network.HTTP.Types.Status   (status200, status404, status413, Status)
-import           Network.Wai                 (Middleware, RequestBodyLength (..),
-                                              Application, requestBodyLength, responseLBS,
-                                              Response, ResponseReceived, Request, requestHeaders
-                                             )
-import           Network.Wai.UrlMap (mapUrls, mount, mountRoot)
-import           Network.Wai.Parse           (fileContent)
+import           Network.HTTP.Types          (StdMethod (POST), parseMethod)
+import           Network.HTTP.Types.Status   (Status, status200, status404,
+                                              status413, status500)
+import           Network.Wai                 (Application, Middleware, Request,
+                                              RequestBodyLength (..), Response,
+                                              requestBodyLength, requestHeaders,
+                                              requestMethod, responseLBS)
+import           Network.Wai.Parse           (File, Param,
+                                              defaultParseRequestBodyOptions,
+                                              fileContent, lbsBackEnd,
+                                              parseRequestBodyEx)
+import           Network.Wai.UrlMap          (mapUrls, mount, mountRoot)
 import           Universum
 
 import           Pos.ReportServer.ClientInfo (clientInfo)
-import           Pos.ReportServer.Exception  (ReportServerException (BadRequest), tryAll)
+import           Pos.ReportServer.Exception  (ReportServerException (BadRequest),
+                                              tryAll)
 import           Pos.ReportServer.FileOps    (LogsHolder, addEntry)
 import           Pos.ReportServer.Report     (ReportInfo (..))
 
@@ -51,40 +58,38 @@ liftAndCatchIO
     => IO a -> m (Either ReportServerException a)
 liftAndCatchIO = tryAll . liftIO
 
-type Responder = Response -> IO ResponseReceived
-
 withStatus :: Status -> T.Text -> Request -> Response
 withStatus status msg req = responseLBS status (requestHeaders req) (encodeUtf8 msg)
 
+-- | Gets the list of the uploaded files.
+bodyParse :: Request -> IO ([Param], [File LByteString])
+bodyParse request = do
+    let parseBodyOptions = defaultParseRequestBodyOptions
+    parseRequestBodyEx parseBodyOptions lbsBackEnd request
+
+-- Tries to retrieve the `ReportInfo` from the raw `Request`.
+param :: ByteString -> [Param] -> ByteString
+param key = fromMaybe mempty . lookup key
 
 reportApp :: LogsHolder -> Application
 reportApp holder req respond =
-    respond (withStatus status200 "To be done" req)
-
-{-
-    post "/report" $ do
-        (payload :: ReportInfo) <-
-            either failPayload pure . eitherDecode =<< param "payload"
-        logFiles <-
-            map (bimap LT.toStrict $ TE.decodeUtf8 . BSL.toStrict . fileContent) <$>
-            files
-        let missingLogs = rLogs payload \\ map fst logFiles
-        unless (null missingLogs) $ failMissingLogs missingLogs
-        let neededLogs = filter ((`elem` rLogs payload) . fst) logFiles
-        let payloadFile = ("payload.json", prettifyJson payload)
-        let cInfo = clientInfo req
-        let clientInfoFile = ("client.info", prettifyJson cInfo)
-        liftAndCatchIO $ addEntry holder $ payloadFile : clientInfoFile : neededLogs
-        status status200
--}
-
-notFound :: Application
-notFound req respond = respond (withStatus status404 "Not found" req)
-
-reportServerApp :: LogsHolder -> Application
-reportServerApp holder = mapUrls $
-        mount "report" (reportApp holder)
-    <|> mountRoot notFound
+    case parseMethod (requestMethod req) of
+        Right POST -> do
+          (params, files) <- bodyParse req
+          (payload :: ReportInfo) <-
+              either failPayload pure . eitherDecodeStrict =<< return (param "payload" params)
+          let logFiles = map (bimap decodeUtf8 $ TE.decodeUtf8 . BSL.toStrict . fileContent) files
+          let missingLogs = rLogs payload \\ map fst logFiles
+          unless (null missingLogs) $ failMissingLogs missingLogs
+          let neededLogs = filter ((`elem` rLogs payload) . fst) logFiles
+          let payloadFile = ("payload.json", prettifyJson payload)
+          let cInfo = clientInfo req
+          let clientInfoFile = ("client.info", prettifyJson cInfo)
+          res <- liftAndCatchIO $ addEntry holder $ payloadFile : clientInfoFile : neededLogs
+          case res of
+              Left e -> respond (with500Response (toText $ displayException e) req)
+              _      -> respond (with200Response req)
+        _  -> respond (with404Response req)
   where
     prettifyJson :: (ToJSON a) => a -> Text
     prettifyJson = TE.decodeUtf8 . BSL.toStrict . encodePretty
@@ -92,3 +97,20 @@ reportServerApp holder = mapUrls $
         throwM $ BadRequest $ "Logs mentioned in payload were not attached: " <> show missing
     failPayload e =
         throwM $ BadRequest $ "Couldn't manage to parse json payload: " <> T.pack e
+
+with404Response :: Request -> Response
+with404Response = withStatus status404 "Not found"
+
+with200Response :: Request -> Response
+with200Response = withStatus status200 mempty
+
+with500Response :: Text -> Request -> Response
+with500Response = withStatus status500
+
+notFound :: Application
+notFound req respond = respond (with404Response req)
+
+reportServerApp :: LogsHolder -> Application
+reportServerApp holder = mapUrls $
+        mount "report" (reportApp holder)
+    <|> mountRoot notFound

--- a/src/exec/Main.hs
+++ b/src/exec/Main.hs
@@ -21,5 +21,5 @@ main = do
     putText "Successfully created holder"
 
     putText "Launching server..."
-    application <- S.scottyAppT liftIO $ reportServerApp holder
+    let application = reportServerApp holder
     Warp.run port $ logStdoutDev $ limitBodySize sizeLimit $ application

--- a/src/exec/Main.hs
+++ b/src/exec/Main.hs
@@ -7,7 +7,6 @@ module Main (main) where
 import qualified Network.Wai.Handler.Warp             as Warp
 import           Network.Wai.Middleware.RequestLogger (logStdoutDev)
 import           Universum
-import qualified Web.Scotty.Trans                     as S
 
 import           Options                              (Opts (..), getOptions)
 import           Pos.ReportServer.FileOps             (initHolder)

--- a/src/exec/Options.hs
+++ b/src/exec/Options.hs
@@ -9,9 +9,13 @@ module Options
        ) where
 
 import           Data.Char                   (toLower, toUpper)
-import           Options.Applicative         (ReadM, eitherReader)
-import           Options.Applicative.Simple  (Parser, auto, help, long, metavar, option,
-                                              short, simpleOptions, strOption, value)
+import           Options.Applicative         (Parser, ReadM, auto, eitherReader,
+                                              execParserPure, fullDesc,
+                                              handleParseResult, header, help,
+                                              helper, idm, info, infoOption,
+                                              long, metavar, option, prefs,
+                                              progDesc, short, strOption, value,
+                                              (<**>))
 import           System.Directory            (getHomeDirectory)
 import           System.FilePath             ((</>))
 import           System.Wlog.Severity        (Severity (..))
@@ -64,11 +68,10 @@ optsParser homeDir =
 getOptions :: IO Opts
 getOptions = do
     homeDir <- getHomeDirectory
-    (res, ()) <-
-        simpleOptions
-            ("cardano-report-server version " <> show version)
-            "CardanoSL report server"
-            "CardanoSL reporting server daemon"
-            (optsParser homeDir)
-            empty
-    return res
+    getArgs >>= handleParseResult . execParserPure (prefs idm) (parser homeDir)
+    where
+       parser homeDir = info (optsParser homeDir <**> helper <**> versionHelper) desc
+       desc = fullDesc <> header "CardanoSL report server" <> progDesc "CardanoSL reporting server daemon"
+       versionHelper =
+         infoOption ("cardano-report-server version " <> show version)
+                    (long "version" <> help "Show version")


### PR DESCRIPTION
This PR removes `scotty` from `cardano-report-server`, in the attempt of pruning the overall deps from `cardano`.

I have checked that I can indeed run `cardano-report-server` and the tests still passes, but it would be nice to understand if this is still working as before.

It would be awesome to have a proper review (maybe from @gromakovsky ? 😉 ) and being pointed out to instructions on how I can upload a `payload` to this thing and what should be the expected output.

Thanks!