### PR TITLE
[CSL-1753] Hierarchical reports

### DIFF
--- a/cardano-report-server.cabal
+++ b/cardano-report-server.cabal
@@ -1,5 +1,5 @@
 name:                cardano-report-server
-version:             0.3.0
+version:             0.4.0
 synopsis:            Reporting server for CSL
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-report-server

--- a/src/Pos/ReportServer/ClientInfo.hs
+++ b/src/Pos/ReportServer/ClientInfo.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+
 -- | Information about client we want to store.
 
 module Pos.ReportServer.ClientInfo
@@ -18,7 +19,7 @@ import           Formatting.Formatters     (hex)
 import           Network.HTTP.Types.Header (Header)
 import           Network.Socket            (hostAddressToTuple)
 import           Network.Socket.Internal   (SockAddr (..))
-import           Network.Wai               (isSecure, remoteHost, requestHeaders, Request)
+import           Network.Wai               (Request, isSecure, remoteHost, requestHeaders)
 import           Universum                 hiding (decodeUtf8)
 
 newtype SockAddrW = SockAddrW SockAddr

--- a/src/Pos/ReportServer/FileOps.hs
+++ b/src/Pos/ReportServer/FileOps.hs
@@ -50,10 +50,10 @@ genReportPath curTime ReportInfo{..} =
     date </> repType </> time
   where
     repType = case rReportType of
-                  RCrash _         -> "crash"
-                  RError _         -> "error"
-                  RMisbehavior{..} -> "misbehavior"
-                  RInfo _          -> "info"
+                  RCrash _       -> "crash"
+                  RError _       -> "error"
+                  RMisbehavior{} -> "misbehavior"
+                  RInfo _        -> "info"
     time = formatTime defaultTimeLocale "%T_%Z_%q" curTime
     date = formatTime defaultTimeLocale "%F" curTime
 

--- a/src/Pos/ReportServer/FileOps.hs
+++ b/src/Pos/ReportServer/FileOps.hs
@@ -17,26 +17,45 @@ import qualified Data.Text                  as T
 import qualified Data.Text.IO               as TIO
 import           Data.Time                  (UTCTime, getCurrentTime)
 import           Data.Time.Format           (defaultTimeLocale, formatTime, parseTimeM)
-import           System.Directory           (createDirectory, createDirectoryIfMissing,
-                                             doesFileExist)
+import           System.Directory           (createDirectoryIfMissing, doesFileExist)
 import           System.FilePath            ((</>))
-import           System.Random              (randomRIO)
 
 import           Pos.ReportServer.Exception (ReportServerException (MalformedIndex))
-import           Pos.ReportServer.Util      (withFileWriteLifted)
+import           Pos.ReportServer.Report    (ReportInfo (..), ReportType (..))
+import           Pos.ReportServer.Util      (prettifyJson, withFileWriteLifted)
 
 
 indexFileName :: FilePath
 indexFileName = "index.log"
 
-dateFormat :: [Char]
-dateFormat = "%F_%T_%Z"
+-- | Date format stored in index file.
+indexDateFormat, indexDateFormatOld :: [Char]
+indexDateFormat = "%F_%T_%Z_%q"
+indexDateFormatOld = "%F_%T_%Z"
 
+-- | Datatype that identifies log storage.
 data LogsHolder = LogsHolder
     { lhDir    :: FilePath
+      -- ^ Root directory we store everything in.
     , lhIndex  :: FilePath
+      -- ^ Path to the index file.
     , lhLastIx :: MVar Int
+      -- ^ Id that we can take when processing new report.
     }
+
+-- | Given a report info, generates a (relative) path to directory
+-- where data will be stored.
+genReportPath :: UTCTime -> ReportInfo -> FilePath
+genReportPath curTime ReportInfo{..} =
+    date </> repType </> time
+  where
+    repType = case rReportType of
+                  RCrash _         -> "crash"
+                  RError _         -> "error"
+                  RMisbehavior{..} -> "misbehavior"
+                  RInfo _          -> "info"
+    time = formatTime defaultTimeLocale "%T_%Z_%q" curTime
+    date = formatTime defaultTimeLocale "%F" curTime
 
 -- | Parses single line of index -- returns index id, time item created
 -- on and subdir name.
@@ -46,11 +65,9 @@ parseIndexEntry line = case T.splitOn "," line of
         ix <- mToE ("Couldn't read index: " <> a) $ readMaybe $ T.unpack a
         time <-
             mToE ("Couldn't parse utctime: " <> b) $
-            parseTimeM True defaultTimeLocale dateFormat (T.unpack b)
-        let fpath = T.unpack c
-        when ("/" `T.isInfixOf` c) $
-            Left $ "Filepath has '/' inside it: " <> c
-        pure $ (ix, time, fpath)
+            parseTimeM True defaultTimeLocale indexDateFormat (T.unpack b) <|>
+            parseTimeM True defaultTimeLocale indexDateFormatOld (T.unpack b)
+        pure $ (ix, time, toString c)
     _ -> Left $ "Expected csv with 3 argument, got: " <> line
   where
     mToE reason = maybe (Left reason) Right
@@ -75,21 +92,21 @@ initHolder dir = do
 
 -- | Given logs holder and list of (filename,content), create a new
 -- logs dir, dump files there and place an entry to index.
-addEntry :: LogsHolder -> [(Text, Text)] -> IO ()
-addEntry LogsHolder{..} files = do
-    timestamp <-
-        formatTime defaultTimeLocale dateFormat <$>
-        getCurrentTime
-    (nonce :: Integer) <- randomRIO (0, 100000000)
-    let dirname = "logs_" <> timestamp <> "_" <> show nonce
-    let fullDirname = lhDir </> dirname
-    createDirectory fullDirname
-    forM_ files $ \(fname,content) ->
+addEntry :: LogsHolder -> ReportInfo -> [(Text, Text)] -> IO ()
+addEntry LogsHolder{..} reportInfo files = do
+    curTime <- getCurrentTime
+    let reportDir = genReportPath curTime reportInfo
+    let fullDirname = lhDir </> reportDir
+    let timestamp = formatTime defaultTimeLocale indexDateFormat curTime
+    createDirectoryIfMissing True fullDirname
+
+    let filesToWrite = ("payload.json", prettifyJson reportInfo) : files
+    forM_ filesToWrite $ \(fname,content) ->
         TIO.writeFile (fullDirname </> T.unpack fname) content
     modifyMVar_ lhLastIx $ \i -> do
         let entry =
                 T.intercalate ","
-                ([show i, T.pack timestamp, T.pack dirname])
+                ([show i, T.pack timestamp, T.pack fullDirname])
                 <> "\n"
         withFileWriteLifted lhIndex $ TIO.appendFile lhIndex entry
         pure $ i + 1

--- a/src/Pos/ReportServer/Server.hs
+++ b/src/Pos/ReportServer/Server.hs
@@ -10,10 +10,9 @@ module Pos.ReportServer.Server
 
 import           Control.Exception           (displayException, throwIO)
 import           Control.Monad.Trans.Control (MonadBaseControl)
-import           Data.Aeson                  (ToJSON, eitherDecodeStrict)
-import           Data.Aeson.Encode.Pretty    (encodePretty)
+import           Data.Aeson                  (eitherDecodeStrict)
 import qualified Data.ByteString.Lazy        as BSL
-import           Data.List                   (lookup, (\\))
+import           Data.List                   (lookup)
 import qualified Data.Text                   as T
 import qualified Data.Text.Encoding          as TE (decodeUtf8)
 import           Network.HTTP.Types          (StdMethod (POST), parseMethod)
@@ -34,6 +33,7 @@ import           Pos.ReportServer.Exception  (ReportServerException (BadRequest,
                                               tryAll)
 import           Pos.ReportServer.FileOps    (LogsHolder, addEntry)
 import           Pos.ReportServer.Report     (ReportInfo (..))
+import           Pos.ReportServer.Util       (prettifyJson)
 
 
 limitBodySize :: Word64 -> Middleware
@@ -81,10 +81,9 @@ reportApp holder req respond =
           (payload :: ReportInfo) <-
               either failPayload pure . eitherDecodeStrict =<< param "payload" params
           let logFiles = map (bimap decodeUtf8 $ TE.decodeUtf8 . BSL.toStrict . fileContent) files
-          let payloadFile = ("payload.json", prettifyJson payload)
           let cInfo = clientInfo req
           let clientInfoFile = ("client.info", prettifyJson cInfo)
-          res <- liftAndCatchIO $ addEntry holder $ payloadFile : clientInfoFile : logFiles
+          res <- liftAndCatchIO $ addEntry holder payload $ clientInfoFile : logFiles
           case res of
               Right _ ->
                   respond (with200Response req)
@@ -94,8 +93,6 @@ reportApp holder req respond =
                   respond (with500Response (toText ex) req)
         _  -> respond (with404Response req)
   where
-    prettifyJson :: (ToJSON a) => a -> Text
-    prettifyJson = TE.decodeUtf8 . BSL.toStrict . encodePretty
     failPayload e =
         throwM $ BadRequest $ "Couldn't manage to parse json payload: " <> T.pack e
 

--- a/src/Pos/ReportServer/Util.hs
+++ b/src/Pos/ReportServer/Util.hs
@@ -1,12 +1,19 @@
--- | Utilities
+-- | Utilities.
 
 module Pos.ReportServer.Util
        ( withFileReadLifted
        , withFileWriteLifted
+       , prettifyJson
        ) where
 
-import           System.FileLock (SharedExclusive (..), lockFile, unlockFile)
 import           Universum
+
+import           Data.Aeson               (ToJSON)
+import           Data.Aeson.Encode.Pretty (encodePretty)
+import qualified Data.ByteString.Lazy     as BSL
+import qualified Data.Text.Encoding       as TE (decodeUtf8)
+import           System.FileLock          (SharedExclusive (..), lockFile, unlockFile)
+
 
 -- | Execute MonadIO action with read/shared lock on the file.
 withFileReadLifted :: (MonadIO m, MonadMask m) => FilePath -> m a -> m a
@@ -23,3 +30,7 @@ withFileModLifted lockType fp action =
     bracket (liftIO $ lockFile fp lockType)
             (\x -> liftIO $ unlockFile x)
             (const action)
+
+-- | Encodes json file in a pretty way.
+prettifyJson :: (ToJSON a) => a -> Text
+prettifyJson = TE.decodeUtf8 . BSL.toStrict . encodePretty

--- a/test/MainSpec.hs
+++ b/test/MainSpec.hs
@@ -16,8 +16,8 @@ import           Data.Version            (Version (..))
 import           Test.Hspec              (Spec, describe)
 import           Test.Hspec.QuickCheck   (prop)
 import           Test.QuickCheck         (Arbitrary (arbitrary), Gen, choose,
-                                          counterexample, elements, getPositive, listOf,
-                                          listOf1, oneof, scale, (===))
+                                          counterexample, elements, getPositive, listOf1,
+                                          oneof, scale, (===))
 import           Universum
 
 import           Pos.ReportServer.Report (ReportInfo (..), ReportType (..), supportedApps)
@@ -49,10 +49,9 @@ instance Arbitrary ReportInfo where
         rVersion <-
             Version <$> listOf1 (getPositive <$> arbitrary)
                     <*> (pure empty)
-        rBuild <- choose (0,1000)
+        rBuild <- show <$> choose (0,1000::Int)
         rOS <- scale (min 100) arbitrary
         rDate <- arbitrary
-        rLogs <- listOf arbitrary
         rMagic <- arbitrary
         rReportType <- arbitrary
         pure $ ReportInfo{..}


### PR DESCRIPTION
What was done:
1. Report directory format changed to `date </> reportType </> timestamp`.
2. `rLogs` field was removed from `ReportInfo` -- it was redundant
3. `rBuild` changed type to `Text` in case we will want to put git revision there.
Changes do not break backward compatibility.