### PR TITLE
[CSL-1732] Allow arbitrary binary blobs in report attachment

### DIFF
--- a/cardano-report-server.cabal
+++ b/cardano-report-server.cabal
@@ -1,5 +1,5 @@
 name:                cardano-report-server
-version:             0.4.0
+version:             0.4.1
 synopsis:            Reporting server for CSL
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-report-server


### PR DESCRIPTION
Previously, files attached to report message had to be utf-8 encode log files. Now, after we decided to support sending archives to report server, this limitation was removed. Change is compatible with previous version of report server.