### PR TITLE
[CSL-2125] Bump up to GHC-8.2.2

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,247 @@
+# Stylish-haskell configuration file used for cardano-sl by Serokell.
+# It's based on default config provided by `stylish-haskell --defaults` but has some changes
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+
+      # Note: we intentionally disable it to make diffs less verbose and avoid
+      # merge conflicts in some cases.
+      pad_module_names: false
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account. Default: 80.
+#
+# Note: we tend to write code which fits into 80 characters, in some cases
+# 100 is acceptable. For imports we always permit 100 characters because it
+# decreases verbosity of diffs and makes merging easier.
+columns: 100
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# These syntax-affecting language extensions are enabled so that
+# stylish-haskell wouldn't fail with parsing errors when processing files
+# in projects that have those extensions enabled in the .cabal file
+# rather than locally.
+#
+# To my best knowledge, no harm should result from enabling an extension
+# that isn't actually used in the file/project. —@neongreen
+language_extensions:
+  - BangPatterns
+  - ConstraintKinds
+  - DataKinds
+  - DefaultSignatures
+  - DeriveDataTypeable
+  - DeriveGeneric
+  - FlexibleContexts
+  - FlexibleInstances
+  - FunctionalDependencies
+  - GADTs
+  - GeneralizedNewtypeDeriving
+  - LambdaCase
+  - MultiParamTypeClasses
+  - MultiWayIf
+  - NoImplicitPrelude
+  - OverloadedStrings
+  - PolyKinds
+  - RecordWildCards
+  - ScopedTypeVariables
+  - StandaloneDeriving
+  - TemplateHaskell
+  - TupleSections
+  - TypeApplications
+  - TypeFamilies
+  - ViewPatterns

--- a/cardano-report-server.cabal
+++ b/cardano-report-server.cabal
@@ -1,5 +1,5 @@
 name:                cardano-report-server
-version:             0.4.1
+version:             0.4.2
 synopsis:            Reporting server for CSL
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-report-server
@@ -7,7 +7,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Volkhov Mikhail
 maintainer:          volhovm.cs@gmail.com
-copyright:           2017 IOHK
+copyright:           2017-2018 IOHK
 category:            Web
 build-type:          Simple
 extra-source-files:  README.md
@@ -21,6 +21,7 @@ library
                      , Pos.ReportServer.FileOps
                      , Pos.ReportServer.Server
                      , Pos.ReportServer.Util
+                     , Paths_cardano_report_server
   build-depends:       aeson >= 0.11.2.1
                      , aeson-pretty >= 0.8.2
                      , base >= 4.9.0.0 && < 5.0.0.0
@@ -69,6 +70,7 @@ executable cardano-report-server
   hs-source-dirs:      src/exec
   main-is:             Main.hs
   other-modules:       Options
+                     , Paths_cardano_report_server
   build-depends:       base >= 4.9.0.0 && < 5.0.0.0
                      , cardano-report-server
                      , directory >= 1.2.6.2
@@ -106,7 +108,7 @@ test-suite cardano-report-server-test
   build-depends:       HUnit >= 1.3.1.2
                      , QuickCheck
                      , aeson >= 0.11.2.1
-                     , base >=4.9 && <4.10
+                     , base >=4.9 && < 5
                      , cardano-report-server
                      , hspec
                      , lens

--- a/src/Pos/ReportServer/Report.hs
+++ b/src/Pos/ReportServer/Report.hs
@@ -8,17 +8,15 @@ module Pos.ReportServer.Report
        , ReportInfo(..)
        ) where
 
-import           Data.Aeson                   (FromJSON (..), ToJSON (..),
-                                               Value (Object, String), object, (.:), (.=))
-import           Data.Aeson.Types             (typeMismatch)
-import           Data.List                    (last)
-import qualified Data.Text                    as T
-import           Data.Time                    (UTCTime)
-import           Data.Time.Format             (defaultTimeLocale, formatTime,
-                                               iso8601DateFormat, parseTimeM)
-import           Data.Version                 (Version (..), parseVersion, showVersion)
-import           Text.ParserCombinators.ReadP (readP_to_S)
 import           Universum
+
+import           Data.Aeson (FromJSON (..), ToJSON (..), Value (Object, String), object, (.:), (.=))
+import           Data.Aeson.Types (typeMismatch)
+import qualified Data.Text as T
+import           Data.Time (UTCTime)
+import           Data.Time.Format (defaultTimeLocale, formatTime, iso8601DateFormat, parseTimeM)
+import           Data.Version (Version (..), parseVersion, showVersion)
+import           Text.ParserCombinators.ReadP (readP_to_S)
 
 -- | Type of report.
 data ReportType
@@ -99,8 +97,8 @@ supportedApps = ["daedalus", "cardano-node"]
 readVersion :: (ToString a) => a -> Maybe Version
 readVersion (toString -> s) =
     case readP_to_S parseVersion s of
-        [] -> Nothing
-        xs -> Just $ fst $ last xs
+        []     -> Nothing
+        (x:xs) -> Just $ fst $ last (x :| xs)
 
 -- YYYY-MM-DDTHH:MM:SS
 iso8601DateTimeFormat :: [Char]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,8 @@
-resolver: lts-9.1
-
-packages:
-- '.'
+resolver: lts-10.3
 
 nix:
   shell-file: shell.nix
 
 extra-deps:
-- universum-0.6.1
-- log-warper-1.2.0
+- universum-1.0.4
+- log-warper-1.8.6


### PR DESCRIPTION
Use LTS 10.3 + `universum-1.0.4` + `log-warper-1.8.6`.

Required for https://github.com/input-output-hk/cardano-sl/pull/2327